### PR TITLE
Refactor useInvalidateQueries import and create new file

### DIFF
--- a/src/app/(protected)/_components/orders/PackingPendingDialog.tsx
+++ b/src/app/(protected)/_components/orders/PackingPendingDialog.tsx
@@ -23,7 +23,7 @@ import axios from 'axios';
 import { toast } from 'sonner';
 import { error } from 'console';
 import { packedOrder } from '@/src/actions/order';
-import { useInvalidateQueries } from '../../orders/layout';
+import { useInvalidateQueries } from '../../orders/useInvalidateQueries';
 interface ViewOrderDialogProps {
     data: any
 }

--- a/src/app/(protected)/_components/orders/TrackingPendingOrders.tsx
+++ b/src/app/(protected)/_components/orders/TrackingPendingOrders.tsx
@@ -37,7 +37,7 @@ import { Calendar } from '@/src/components/ui/calendar';
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/src/components/ui/dialog';
 import PackingPending from './PackingPendingDialog';
 import { Input } from '@/src/components/ui/input';
-import { useInvalidateQueries } from '../../orders/layout';
+import { useInvalidateQueries } from '../../orders/useInvalidateQueries';
 import TrackingDialog from './TrackingDialog';
 
 interface Order {

--- a/src/app/(protected)/_components/request/moderatorRow.tsx
+++ b/src/app/(protected)/_components/request/moderatorRow.tsx
@@ -47,6 +47,7 @@ interface userProps {
   isTwoFactorEnabled: boolean;
   balance: number | null;
   groupName: string | null;
+  creditLimit: number | null;
 }
 
 interface moderatorRowProps {

--- a/src/app/(protected)/orders/layout.tsx
+++ b/src/app/(protected)/orders/layout.tsx
@@ -7,10 +7,6 @@ interface ProtectedLayoutProps {
     children: React.ReactNode;
 }
 
-export const useInvalidateQueries = () => {
-    return () => {};
-};
-
 const OrdersLayout = ({ children }: ProtectedLayoutProps) => {
     return (
         <Card className="w-full h-full rounded-none">

--- a/src/app/(protected)/orders/useInvalidateQueries.ts
+++ b/src/app/(protected)/orders/useInvalidateQueries.ts
@@ -1,0 +1,5 @@
+"use client";
+
+export const useInvalidateQueries = () => {
+    return () => {};
+};


### PR DESCRIPTION
- Updated import paths for useInvalidateQueries in PackingPendingDialog and TrackingPendingOrders components to reflect the new file structure.
- Created a new useInvalidateQueries.ts file to define the useInvalidateQueries function, improving code organization and maintainability.
- Added creditLimit property to userProps interface in moderatorRow component for enhanced user data management.